### PR TITLE
Migrate flake to UV

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,37 @@ it to make it more convenient.
 yay -S nextmeeting
 ```
 
+### NixOS
+<details><summary>Flake and Home-Manager install instructions.</summary>
+
+1. Add nextmeeting to your flake.
+
+```nix
+nextmeeting = {
+  url = "github:chmouel/nextmeeting?dir=packaging";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+2. Use Home-manager to add nextmeeting to waybar like this:
+
+```nix
+let 
+  nextmeeting = lib.getExe inputs.nextmeeting.packages.${pkgs.system}.default;
+in
+{
+  "custom/agenda" = {
+      format = "{}";
+      exec = nextmeeting + "--max-title-length 30 --waybar";
+      on-click = nextmeeting + "--open-meet-url";
+      interval = 59;
+      return-type = "json";
+      tooltip = true;
+  };
+}
+```
+3. Follow along with the rest of the instructions.
+</details>
+
 ## How to use it?
 
 You need to install [gcalcli](https://github.com/insanum/gcalcli) and [setup

--- a/packaging/flake.lock
+++ b/packaging/flake.lock
@@ -18,27 +18,6 @@
         "type": "github"
       }
     },
-    "nix-github-actions": {
-      "inputs": {
-        "nixpkgs": [
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1720066371,
-        "narHash": "sha256-uPlLYH2S0ACj0IcgaK9Lsf4spmJoGejR9DotXiXSBZQ=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "622f829f5fe69310a866c8a6cd07e747c44ef820",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1728241625,
@@ -55,37 +34,10 @@
         "type": "github"
       }
     },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nix-github-actions": "nix-github-actions",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": "systems_2",
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1728266256,
-        "narHash": "sha256-RefXB9kqYch6uGT+mo6m3KTbNerfbDYz+EqkLb6YBbs=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "8e965fd42c0da4357c53d987bc62b54a954424da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "poetry2nix": "poetry2nix"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -100,41 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "id": "systems",
-        "type": "indirect"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1727984844,
-        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/packaging/flake.nix
+++ b/packaging/flake.nix
@@ -37,6 +37,9 @@
           preferWheelPhase = ''
             export PIP_PREFER_BINARY=1
           '';
+          meta = {
+            mainProgram = "nextmeeting";
+          };
         };
         default = self.packages.${system}.nextmeeting;
       };

--- a/packaging/flake.nix
+++ b/packaging/flake.nix
@@ -3,44 +3,56 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.poetry2nix = {
-    url = "github:nix-community/poetry2nix";
-    inputs.nixpkgs.follows = "nixpkgs";
-    inputs.flake-utils.follows = "flake-utils";
-  };
 
   outputs = {
     self,
     nixpkgs,
     flake-utils,
-    poetry2nix,
   }:
     flake-utils.lib.eachDefaultSystem (system: let
-      p2n = import poetry2nix {inherit pkgs;};
-      python = pkgs.python3;
-      projectDir = ../.;
-      overrides = p2n.overrides.withDefaults (final: prev: {
-        # use wheels to build ruff & mypy
-        ruff = prev.ruff.override {
-          preferWheel = true;
-        };
-        mypy = prev.mypy.override {
-          preferWheel = true;
-        };
-      });
-      poetry_env = p2n.mkPoetryEnv {
-        inherit python projectDir overrides;
-      };
-      poetry_app = p2n.mkPoetryApplication {
-        inherit python projectDir overrides;
-      };
       pkgs = nixpkgs.legacyPackages.${system};
+      python = pkgs.python3;
+      pythonEnv = python.withPackages (ps: with ps; [
+        python-dateutil
+      ]);
     in {
       packages = {
-        nextmeeting = poetry_app;
+        nextmeeting = pkgs.python3Packages.buildPythonPackage {
+          pname = "nextmeeting";
+          version = "1.5.5";
+          src = ../.;
+          propagatedBuildInputs = [ pythonEnv ];
+          pythonImportsCheck = [ "nextmeeting" ];
+          format = "pyproject";
+          nativeBuildInputs = [
+            pkgs.python3Packages.hatchling
+          ];
+          # Add development tools to the package
+          checkInputs = [
+            pkgs.ruff
+            pkgs.python3Packages.mypy
+          ];
+          # Configure wheel preferences for development tools
+          preBuildPhases = [ "preferWheelPhase" ];
+          preferWheelPhase = ''
+            export PIP_PREFER_BINARY=1
+          '';
+        };
         default = self.packages.${system}.nextmeeting;
       };
-      devShells.default =
-        pkgs.mkShell {packages = [pkgs.poetry poetry_env];};
+      devShells.default = pkgs.mkShell {
+        packages = [
+          pkgs.uv
+          pythonEnv
+          # Development tools
+          pkgs.ruff
+          pkgs.python3Packages.mypy
+        ];
+        shellHook = ''
+          export PYTHONPATH="$PWD:$PYTHONPATH"
+          # Configure wheel preferences
+          export PIP_PREFER_BINARY=1
+        '';
+      };
     });
 }


### PR DESCRIPTION
Hi again @chmouel 

I updated the flake to use UV instead of poetry and kept the dev environment and tooling.

It should build and format the same as your current dev environment. I tested that it works on the NixOS home-manager waybar.

Add instructions for NixOS install to readme (behind details tag so it doesn't confuse.)

fixes #13 