### PR TITLE
Configuration normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ is loaded if present, or you can point to a custom file with `--config`.
 
 Command-line flags map directly to keys in the `[nextmeeting]` table: remove the
 leading `--` and keep hyphen separators (`--max-title-length` → `max-title-length`).
+Both hyphens and underscores work in configuration keys (`caldav-url` and `caldav_url` are equivalent).
 
 Example `~/.config/nextmeeting/config.toml`:
 

--- a/src/nextmeeting/cli.py
+++ b/src/nextmeeting/cli.py
@@ -1190,8 +1190,18 @@ def _load_config(path: Path) -> dict:
             data = tomllib.load(f)
         # Allow a top-level [nextmeeting] table or flat keys
         if "nextmeeting" in data and isinstance(data["nextmeeting"], dict):
-            return data["nextmeeting"]
-        return data
+            config_data = data["nextmeeting"]
+        else:
+            config_data = data
+
+        # Normalize keys: convert hyphens to underscores to match argparse behavior
+        # This allows both caldav-url and caldav_url in config files
+        normalized_config = {}
+        for key, value in config_data.items():
+            normalized_key = key.replace("-", "_")
+            normalized_config[normalized_key] = value
+
+        return normalized_config
     except Exception:  # noqa: BLE001
         return {}
 

--- a/src/nextmeeting/cli.py
+++ b/src/nextmeeting/cli.py
@@ -1196,10 +1196,9 @@ def _load_config(path: Path) -> dict:
 
         # Normalize keys: convert hyphens to underscores to match argparse behavior
         # This allows both caldav-url and caldav_url in config files
-        normalized_config = {}
-        for key, value in config_data.items():
-            normalized_key = key.replace("-", "_")
-            normalized_config[normalized_key] = value
+        normalized_config = {
+            key.replace("-", "_"): value for key, value in config_data.items()
+        }
 
         return normalized_config
     except Exception:  # noqa: BLE001

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,0 +1,106 @@
+import tempfile
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from nextmeeting.cli import _load_config, parse_args
+
+
+def test_load_config_normalizes_hyphens_to_underscores():
+    """Test that configuration keys with hyphens are normalized to underscores."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write("""[nextmeeting]
+caldav-url = "https://example.com/calendar"
+caldav-username = "user"
+caldav-password = "pass"
+max-title-length = 30
+today-only = true
+""")
+        config_path = Path(f.name)
+
+    try:
+        config = _load_config(config_path)
+
+        # All keys should be normalized to underscores
+        assert config["caldav_url"] == "https://example.com/calendar"
+        assert config["caldav_username"] == "user"
+        assert config["caldav_password"] == "pass"
+        assert config["max_title_length"] == 30
+        assert config["today_only"] is True
+
+        # Hyphens should not exist in the keys
+        assert "caldav-url" not in config
+        assert "caldav-username" not in config
+        assert "caldav-password" not in config
+        assert "max-title-length" not in config
+        assert "today-only" not in config
+    finally:
+        os.unlink(config_path)
+
+
+def test_load_config_works_with_both_formats():
+    """Test that both hyphen and underscore formats work in config files."""
+    # Test with hyphens (README format)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write("""[nextmeeting]
+caldav-url = "https://example.com/hyphens"
+caldav-username = "user-hyphens"
+""")
+        config_path_hyphens = Path(f.name)
+
+    # Test with underscores (internal format)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write("""[nextmeeting]
+caldav_url = "https://example.com/underscores"
+caldav_username = "user_underscores"
+""")
+        config_path_underscores = Path(f.name)
+
+    try:
+        # Both should work and produce the same key format
+        config_hyphens = _load_config(config_path_hyphens)
+        config_underscores = _load_config(config_path_underscores)
+
+        # Both should have normalized underscore keys
+        assert "caldav_url" in config_hyphens
+        assert "caldav_username" in config_hyphens
+        assert "caldav_url" in config_underscores
+        assert "caldav_username" in config_underscores
+
+        # Values should be preserved
+        assert config_hyphens["caldav_url"] == "https://example.com/hyphens"
+        assert config_hyphens["caldav_username"] == "user-hyphens"
+        assert config_underscores["caldav_url"] == "https://example.com/underscores"
+        assert config_underscores["caldav_username"] == "user_underscores"
+
+    finally:
+        os.unlink(config_path_hyphens)
+        os.unlink(config_path_underscores)
+
+
+def test_parse_args_accepts_config_with_hyphens():
+    """Test that parse_args properly handles config files with hyphenated keys."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write("""[nextmeeting]
+caldav-url = "https://example.com/config-test"
+caldav-username = "config-user"
+max-title-length = 25
+""")
+        config_path = f.name
+
+    # Clear environment variables that might interfere
+    with patch.dict(os.environ, {}, clear=True):
+        original_argv = sys.argv
+        try:
+            sys.argv = ["nextmeeting", "--config", config_path]
+            args = parse_args()
+
+            # The arguments should be accessible with underscores
+            assert getattr(args, "caldav_url") == "https://example.com/config-test"
+            assert getattr(args, "caldav_username") == "config-user"
+            assert getattr(args, "max_title_length") == 25
+
+        finally:
+            sys.argv = original_argv
+            os.unlink(config_path)

--- a/uv.lock
+++ b/uv.lock
@@ -439,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "nextmeeting"
-version = "2.0.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "caldav" },


### PR DESCRIPTION
This pull request improves configuration file handling in the `nextmeeting` CLI by ensuring that both hyphens and underscores are accepted in configuration keys, making the tool more flexible and user-friendly. It also adds comprehensive tests to verify this normalization logic and updates the documentation to reflect the change.

**Configuration normalization improvements:**

* Updated `_load_config` in `src/nextmeeting/cli.py` to normalize configuration keys by converting hyphens to underscores, ensuring compatibility with both formats and matching argparse behavior.

**Testing enhancements:**

* Added new tests in `tests/test_config_loading.py` to verify that configuration keys with hyphens are correctly normalized to underscores, that both formats work interchangeably, and that `parse_args` properly handles config files with hyphenated keys.

**Documentation update:**

* Modified `README.md` to clarify that both hyphens and underscores are accepted in configuration keys.