### PR TITLE
Fix tomorrow agenda

### DIFF
--- a/src/nextmeeting/cli.py
+++ b/src/nextmeeting/cli.py
@@ -240,7 +240,8 @@ class MeetingFormatter:
         time_format_pref = getattr(self.args, "time_format", "24h")
 
         if date.day != self.today.day:
-            if deltad.days == 0:
+            tomorrow = self.today.date() + datetime.timedelta(days=1)
+            if date.date() == tomorrow:
                 s = "Tomorrow"
             else:
                 s = f"{date.strftime('%a %d')}"


### PR DESCRIPTION
Tomorrow agenda (after 24h is not properly displayed as `Tomorrow`).
Before the fix (the event `(No title)` should appear as `Tomorrow`, but appears as `Tue 24`):
```
$ nextmeeting
• Tomorrow at 13H45 - Perf&Scale Weekly Telco Sync Up Meeting
• Tomorrow at 15H00 - Q1 26 Global Eng All Hands
• Tomorrow at 15H00 - OCP PerfScale Team Sync
• Tue 24 at 20H30 - (No title)
```

After the fix:
```
$ nextmeeting
• Tomorrow at 13H45 - Perf&Scale Weekly Telco Sync Up Meeting
• Tomorrow at 15H00 - Q1 26 Global Eng All Hands
• Tomorrow at 15H00 - OCP PerfScale Team Sync
• Tomorrow at 20H30 - (No title)
```