### PR TITLE
feat: expose nix overlay

### DIFF
--- a/packaging/flake.nix
+++ b/packaging/flake.nix
@@ -10,13 +10,16 @@
       nixpkgs,
       flake-utils,
     }:
-    flake-utils.lib.eachDefaultSystem (
+    {
+      overlays.default = final: prev: {
+        nextmeeting = final.python3Packages.callPackage ./package.nix { };
+      };
+    }
+    // flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        projectData = builtins.fromTOML (builtins.readFile ../pyproject.toml);
-        python = pkgs.python3;
-        pythonEnv = python.withPackages (
+        pythonEnv = pkgs.python3.withPackages (
           ps: with ps; [
             python-dateutil
             caldav
@@ -25,30 +28,10 @@
       in
       {
         packages = {
-          nextmeeting = pkgs.python3Packages.buildPythonPackage {
-            pname = "nextmeeting";
-            version = projectData.project.version;
-            src = pkgs.lib.cleanSource ../.;
-            propagatedBuildInputs = [ pythonEnv ];
-            pythonImportsCheck = [ "nextmeeting" ];
-            format = "pyproject";
-            nativeBuildInputs = [ pkgs.python3Packages.hatchling ];
-            # Add development tools to the package
-            checkInputs = [
-              pkgs.ruff
-              pkgs.python3Packages.mypy
-            ];
-            # Configure wheel preferences for development tools
-            preBuildPhases = [ "preferWheelPhase" ];
-            preferWheelPhase = ''
-              export PIP_PREFER_BINARY=1
-            '';
-            meta = {
-              mainProgram = "nextmeeting";
-            };
-          };
+          nextmeeting = pkgs.python3Packages.callPackage ./package.nix { };
           default = self.packages.${system}.nextmeeting;
         };
+
         devShells.default = pkgs.mkShell {
           packages = [
             pkgs.uv

--- a/packaging/package.nix
+++ b/packaging/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  hatchling,
+  python-dateutil,
+  caldav,
+  ruff,
+  mypy,
+}:
+let
+  projectData = builtins.fromTOML (builtins.readFile ../pyproject.toml);
+in
+buildPythonPackage {
+  pname = projectData.project.name;
+  version = projectData.project.version;
+  src = lib.cleanSource ../.;
+  pyproject = true;
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    python-dateutil
+    caldav
+  ];
+
+  # prefer prebuilt wheels for the dev tooling
+  preBuildPhases = [ "preferWheelPhase" ];
+  preferWheelPhase = ''
+    export PIP_PREFER_BINARY=1
+  '';
+
+  nativeCheckInputs = [
+    ruff
+    mypy
+  ];
+
+  pythonImportsCheck = [ "nextmeeting" ];
+
+  meta = {
+    description = projectData.project.description;
+    homepage = "https://github.com/chmouel/nextmeeting";
+    license = lib.licenses.asl20;
+    mainProgram = "nextmeeting";
+  };
+}


### PR DESCRIPTION
Hi there.

this PR adds a nix overlay to the flake.

it allows downstream consumers of this flake to override the individual dependencies of this package via their own overlays.

why did i need this:
currently `niquests` (a transitive dependency of nextmeeting) is broken on darwin on nixpkgs-unstable.
i wanted to be able to "inject" a fix, until my upstream PR has been merged.
the overlay allows me to do that cleanly.